### PR TITLE
Fix the canControlStream callback

### DIFF
--- a/src/authUtils.ts
+++ b/src/authUtils.ts
@@ -173,7 +173,8 @@ export function canControlStream(
   stream: ServerStreamIn,
 ): boolean {
   return (
-    getAuthLevel(session) >= AuthLevel.STREAMER &&
-    stream.presenter === session?.uuid
+    (getAuthLevel(session) >= AuthLevel.STREAMER &&
+      stream.presenter === session?.uuid) ||
+    getAuthLevel(session) >= AuthLevel.ADMIN
   );
 }


### PR DESCRIPTION
This allows admins to control all streams, as they should have been able to this whole time.